### PR TITLE
Support cross compiling from linux to x86_64-pc-windows-gnu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ exclude = [
 
 [build-dependencies]
 cmake = "0.1.50"
-bindgen = "0.69.1"
+bindgen = "0.72.1"

--- a/build.rs
+++ b/build.rs
@@ -212,10 +212,22 @@ fn main() {
         let library_root = lib_destination.join("build/libs");
         println!("cargo:rustc-link-search={}", library_root.to_string_lossy());
 
+        // the target operating system (NOT the same as cfg(target_os)
+        // since in a build.rs, this will always be the host system.
+        let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+
         if !matches!(PD_MULTI, "true") {
-            println!("cargo:rustc-link-lib=static=pd");
+            if target_os == "windows" {
+                println!("cargo:rustc-link-lib=static=libpd-static");
+            } else {
+                println!("cargo:rustc-link-lib=static=pd");
+            }
         } else {
-            println!("cargo:rustc-link-lib=static=pd-multi");
+            if target_os == "windows" {
+                println!("cargo:rustc-link-lib=static=libpd-multi-static");
+            } else {
+                println!("cargo:rustc-link-lib=static=pd-multi");
+            }            
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
+#![allow(unnecessary_transmutes)]
 
 //! Rust bindings for [libpd](https://github.com/libpd/libpd).
 //!


### PR DESCRIPTION
When trying to compile for windows on linux, I was encountering a problem about a missing library, turns out I needed a different name for the static library. Note that in a build.rs cfg(target-os) will actually be the host os, because the build script is running on the host os, so to properly detect the case of cross compilation, I have used the cargo environment variable CARGO_CFG_TARGET_OS.

Additionally, I was getting some spurious warnings out of bindgen about unnecessary transmutes. I think this will be fixed in a future version of bindgen, but for now I have simply silenced the warning.

Also I updated bindgen to the latest version because I think that's a chore which is probably good to do. If not, I will revert the change if need be, but everything seems to work on the newer version!

Thanks,
Aaron.